### PR TITLE
[CI] 最適化

### DIFF
--- a/.github/workflows/swift_test.yml
+++ b/.github/workflows/swift_test.yml
@@ -1,4 +1,7 @@
 name: Swift CI
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:
@@ -9,6 +12,7 @@ on:
 jobs:
   build-and-test:
     runs-on: macos-15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
@@ -17,10 +21,15 @@ jobs:
       - name: Cache Swift Packages
         uses: actions/cache@v4
         with:
-          path: .build
+          path: |
+            .build
+            SourcePackages
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
 
       - name: Build and test
         run: |


### PR DESCRIPTION
This pull request updates the Swift CI workflow to improve concurrency management, increase build efficiency, and ensure compatibility with a specific Xcode version. The most important changes include adding concurrency settings, increasing the cache paths for Swift packages, setting a timeout for jobs, and specifying the Xcode version to use.

### Workflow Improvements

* [`.github/workflows/swift_test.yml`](diffhunk://#diff-2e7c29d00fa8d19dd1077e34f95dad8513f2e712cead498d8486e851f5ff0bdbR2-R4): Added concurrency settings to ensure that only one workflow per branch runs at a time, with in-progress workflows being canceled when a new one starts.
* [`.github/workflows/swift_test.yml`](diffhunk://#diff-2e7c29d00fa8d19dd1077e34f95dad8513f2e712cead498d8486e851f5ff0bdbR15): Set a timeout of 30 minutes for the `build-and-test` job to prevent workflows from running indefinitely.

### Build Efficiency

* [`.github/workflows/swift_test.yml`](diffhunk://#diff-2e7c29d00fa8d19dd1077e34f95dad8513f2e712cead498d8486e851f5ff0bdbL20-R33): Expanded the cache paths for Swift packages to include both `.build` and `SourcePackages`, improving build performance by reusing more cached dependencies.

### Compatibility

* [`.github/workflows/swift_test.yml`](diffhunk://#diff-2e7c29d00fa8d19dd1077e34f95dad8513f2e712cead498d8486e851f5ff0bdbL20-R33): Added a step to explicitly select Xcode version 16.4, ensuring compatibility with the build and test process.